### PR TITLE
feat: remove verbose arg from AO2MO

### DIFF
--- a/pymolresponse/ao2mo.py
+++ b/pymolresponse/ao2mo.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Optional
 
 import numpy as np
 
-from pymolresponse.utils import fix_mocoeffs_shape
+from pymolresponse.utils import DirtyMocoeffs, fix_mocoeffs_shape
 
 if TYPE_CHECKING:
     from pymolresponse.indices import Occupations
@@ -18,14 +18,12 @@ class AO2MO:
 
     def __init__(
         self,
-        C: np.ndarray[tuple[int, int, int], np.dtype[np.floating]],
+        C: DirtyMocoeffs,
         occupations: "Occupations",
-        verbose: int = 1,
         I: Optional[np.ndarray[tuple[int, int, int, int], np.dtype[np.floating]]] = None,  # noqa: E741
     ) -> None:
         self.C = fix_mocoeffs_shape(C)
         self.occupations = occupations
-        self.verbose = verbose
         self.I = I
 
         self.nocc_alph, self.nvirt_alph, self.nocc_beta, self.nvirt_beta = occupations
@@ -73,6 +71,8 @@ class AO2MO:
 
     def perform_uhf_full(self) -> None:
         r"""Perform the transformation :math:`(\mu\nu|\lambda\sigma) \rightarrow (p^{\alpha}q^{\alpha}|r^{\alpha}s^{\alpha}), (p^{\alpha}q^{\alpha}|r^{\beta}s^{\beta}), (p^{\beta}q^{\beta}|r^{\alpha}s^{\alpha}), (p^{\beta}q^{\beta}|r^{\beta}s^{\beta})`."""
+        raise NotImplementedError
 
     def perform_uhf_partial(self) -> None:
         r"""Perform the transformation :math:`(\mu\nu|\lambda\sigma) \rightarrow (i^{\alpha}a^{\alpha}|j^{\alpha}b^{\alpha}), (i^{\alpha}a^{\alpha}|j^{\beta}b^{\beta}), (i^{\beta}a^{\beta}|j^{\alpha}b^{\alpha}), (i^{\beta}a^{\beta}|j^{\beta}b^{\beta}), (i^{\alpha}j^{\alpha}|a^{\alpha}b^{\alpha}), (i^{\beta}j^{\beta}|a^{\beta}b^{\beta})`."""
+        raise NotImplementedError

--- a/pymolresponse/interfaces/pyscf/ao2mo.py
+++ b/pymolresponse/interfaces/pyscf/ao2mo.py
@@ -2,29 +2,31 @@
 using pyscf.
 """
 
-from typing import Any, Optional
-
-import numpy as np
+from typing import TYPE_CHECKING
 
 from pyscf.ao2mo import full, general
 
 from pymolresponse.ao2mo import AO2MO
 from pymolresponse.interfaces.pyscf.utils import occupations_from_pyscf_mol
+from pymolresponse.utils import DirtyMocoeffs
+
+if TYPE_CHECKING:
+    from pyscf.gto.mole import Mole
 
 
 class AO2MOpyscf(AO2MO):
     """Perform AO-to-MO transformations using pyscf."""
 
     # TODO what does the pyscf compact kwarg do?
-    def __init__(self, C: np.ndarray, verbose: int = 1, pyscfmol: Optional[Any] = None) -> None:
+    def __init__(self, C: DirtyMocoeffs, pyscfmol: "Mole") -> None:
         self.pyscfmol = pyscfmol
         occupations = occupations_from_pyscf_mol(self.pyscfmol, C)
-        super().__init__(C, occupations, verbose, I=None)
+        super().__init__(C, occupations, I=None)
 
     def perform_rhf_full(self) -> None:
         norb = self.C.shape[-1]
         tei_mo = full(
-            self.pyscfmol, self.C[0], aosym="s4", compact=False, verbose=self.verbose
+            self.pyscfmol, self.C[0], aosym="s4", compact=False, verbose=self.pyscfmol.verbose
         ).reshape(norb, norb, norb, norb)
         self.tei_mo = (tei_mo,)
 
@@ -35,10 +37,10 @@ class AO2MOpyscf(AO2MO):
         C_ovov = (C_occ, C_virt, C_occ, C_virt)
         C_oovv = (C_occ, C_occ, C_virt, C_virt)
         tei_mo_ovov = general(
-            self.pyscfmol, C_ovov, aosym="s4", compact=False, verbose=self.verbose
+            self.pyscfmol, C_ovov, aosym="s4", compact=False, verbose=self.pyscfmol.verbose
         ).reshape(nocc_a, nvirt_a, nocc_a, nvirt_a)
         tei_mo_oovv = general(
-            self.pyscfmol, C_oovv, aosym="s4", compact=False, verbose=self.verbose
+            self.pyscfmol, C_oovv, aosym="s4", compact=False, verbose=self.pyscfmol.verbose
         ).reshape(nocc_a, nocc_a, nvirt_a, nvirt_a)
         self.tei_mo = (tei_mo_ovov, tei_mo_oovv)
 
@@ -51,16 +53,16 @@ class AO2MOpyscf(AO2MO):
         C_bbaa = (C_b, C_b, C_a, C_a)
         C_bbbb = (C_b, C_b, C_b, C_b)
         tei_mo_aaaa = general(
-            self.pyscfmol, C_aaaa, aosym="s4", compact=False, verbose=self.verbose
+            self.pyscfmol, C_aaaa, aosym="s4", compact=False, verbose=self.pyscfmol.verbose
         ).reshape(norb, norb, norb, norb)
         tei_mo_aabb = general(
-            self.pyscfmol, C_aabb, aosym="s4", compact=False, verbose=self.verbose
+            self.pyscfmol, C_aabb, aosym="s4", compact=False, verbose=self.pyscfmol.verbose
         ).reshape(norb, norb, norb, norb)
         tei_mo_bbaa = general(
-            self.pyscfmol, C_bbaa, aosym="s4", compact=False, verbose=self.verbose
+            self.pyscfmol, C_bbaa, aosym="s4", compact=False, verbose=self.pyscfmol.verbose
         ).reshape(norb, norb, norb, norb)
         tei_mo_bbbb = general(
-            self.pyscfmol, C_bbbb, aosym="s4", compact=False, verbose=self.verbose
+            self.pyscfmol, C_bbbb, aosym="s4", compact=False, verbose=self.pyscfmol.verbose
         ).reshape(norb, norb, norb, norb)
         self.tei_mo = (tei_mo_aaaa, tei_mo_aabb, tei_mo_bbaa, tei_mo_bbbb)
 
@@ -78,22 +80,22 @@ class AO2MOpyscf(AO2MO):
         C_oovv_bbbb = (C_occ_beta, C_occ_beta, C_virt_beta, C_virt_beta)
 
         tei_mo_ovov_aaaa = general(
-            self.pyscfmol, C_ovov_aaaa, aosym="s4", compact=False, verbose=self.verbose
+            self.pyscfmol, C_ovov_aaaa, aosym="s4", compact=False, verbose=self.pyscfmol.verbose
         ).reshape(nocc_a, nvirt_a, nocc_a, nvirt_a)
         tei_mo_ovov_aabb = general(
-            self.pyscfmol, C_ovov_aabb, aosym="s4", compact=False, verbose=self.verbose
+            self.pyscfmol, C_ovov_aabb, aosym="s4", compact=False, verbose=self.pyscfmol.verbose
         ).reshape(nocc_a, nvirt_a, nocc_b, nvirt_b)
         tei_mo_ovov_bbaa = general(
-            self.pyscfmol, C_ovov_bbaa, aosym="s4", compact=False, verbose=self.verbose
+            self.pyscfmol, C_ovov_bbaa, aosym="s4", compact=False, verbose=self.pyscfmol.verbose
         ).reshape(nocc_b, nvirt_b, nocc_a, nvirt_a)
         tei_mo_ovov_bbbb = general(
-            self.pyscfmol, C_ovov_bbbb, aosym="s4", compact=False, verbose=self.verbose
+            self.pyscfmol, C_ovov_bbbb, aosym="s4", compact=False, verbose=self.pyscfmol.verbose
         ).reshape(nocc_b, nvirt_b, nocc_b, nvirt_b)
         tei_mo_oovv_aaaa = general(
-            self.pyscfmol, C_oovv_aaaa, aosym="s4", compact=False, verbose=self.verbose
+            self.pyscfmol, C_oovv_aaaa, aosym="s4", compact=False, verbose=self.pyscfmol.verbose
         ).reshape(nocc_a, nocc_a, nvirt_a, nvirt_a)
         tei_mo_oovv_bbbb = general(
-            self.pyscfmol, C_oovv_bbbb, aosym="s4", compact=False, verbose=self.verbose
+            self.pyscfmol, C_oovv_bbbb, aosym="s4", compact=False, verbose=self.pyscfmol.verbose
         ).reshape(nocc_b, nocc_b, nvirt_b, nvirt_b)
         self.tei_mo = (
             tei_mo_ovov_aaaa,

--- a/pymolresponse/solvers.py
+++ b/pymolresponse/solvers.py
@@ -93,7 +93,7 @@ class Solver(ABC):
         if program == Program.PySCF:
             from pymolresponse.interfaces.pyscf.ao2mo import AO2MOpyscf
 
-            ao2mo = AO2MOpyscf(self.mocoeffs, program_obj.verbose, program_obj)
+            ao2mo = AO2MOpyscf(self.mocoeffs, program_obj)
         elif program == Program.Psi4:
             import psi4
 

--- a/pymolresponse/tests/test_ao2mo.py
+++ b/pymolresponse/tests/test_ao2mo.py
@@ -1,5 +1,4 @@
 import numpy as np
-
 import pyscf
 
 from pymolresponse.ao2mo import AO2MO
@@ -21,7 +20,7 @@ def test_ao2mo_hand_against_pyscf_rhf_full() -> None:
     nmo = nocc + nvirt
     ntransforms = 1
 
-    ao2mo = AO2MOpyscf(C, verbose=mol.verbose, pyscfmol=mol)
+    ao2mo = AO2MOpyscf(C, pyscfmol=mol)
     ao2mo.perform_rhf_full()
     assert len(ao2mo.tei_mo) == ntransforms
     tei_mo_pyscf = ao2mo.tei_mo[0]  # ty: ignore[index-out-of-bounds]
@@ -37,7 +36,7 @@ def test_ao2mo_hand_against_pyscf_rhf_full() -> None:
 
     print("2. Use the class method normally.")
 
-    ao2mo_method = AO2MO(C, occupations, verbose=mol.verbose, I=tei_ao)
+    ao2mo_method = AO2MO(C, occupations, I=tei_ao)
     ao2mo_method.perform_rhf_full()
     assert len(ao2mo_method.tei_mo) == ntransforms
     tei_mo_method = ao2mo_method.tei_mo[0]  # ty: ignore[index-out-of-bounds]
@@ -61,7 +60,7 @@ def test_ao2mo_hand_against_pyscf_rhf_partial() -> None:
     o = slice(0, nocc)
     v = slice(nocc, nmo)
 
-    ao2mo = AO2MOpyscf(C, verbose=mol.verbose, pyscfmol=mol)
+    ao2mo = AO2MOpyscf(C, pyscfmol=mol)
     ao2mo.perform_rhf_partial()
     assert len(ao2mo.tei_mo) == ntransforms
     tei_mo_ovov_pyscf = ao2mo.tei_mo[0]  # ty: ignore[index-out-of-bounds]
@@ -81,7 +80,7 @@ def test_ao2mo_hand_against_pyscf_rhf_partial() -> None:
 
     print("2. Use the class method normally.")
 
-    ao2mo_method = AO2MO(C, occupations, verbose=mol.verbose, I=tei_ao)
+    ao2mo_method = AO2MO(C, occupations, I=tei_ao)
     ao2mo_method.perform_rhf_partial()
     assert len(ao2mo_method.tei_mo) == ntransforms
     tei_mo_ovov_method = ao2mo_method.tei_mo[0]  # ty: ignore[index-out-of-bounds]

--- a/pymolresponse/tests/test_rhf.py
+++ b/pymolresponse/tests/test_rhf.py
@@ -1,7 +1,6 @@
 """Hard-coded response equations for restricted wavefunctions."""
 
 import numpy as np
-
 import pyscf
 
 from pymolresponse import explicit_equations_full as eqns
@@ -17,7 +16,7 @@ def test_explicit_rhf_outside_solver_off_diagonal_blocks() -> None:
     mf.kernel()
     mocoeffs = mf.mo_coeff
     moenergies = mf.mo_energy
-    ao2mo = AO2MOpyscf(mocoeffs, mol.verbose, mol)
+    ao2mo = AO2MOpyscf(mocoeffs, mol)
     ao2mo.perform_rhf_full()
     assert len(ao2mo.tei_mo) == 1
     tei_mo = ao2mo.tei_mo[0]  # ty: ignore[index-out-of-bounds]
@@ -74,7 +73,7 @@ def test_explicit_rhf_outside_solver_off_diagonal_blocks() -> None:
 #     mf.kernel()
 #     mocoeffs = mf.mo_coeff
 #     moenergies = mf.mo_energy
-#     ao2mo = AO2MOpyscf(mocoeffs, mol.verbose, mol)
+#     ao2mo = AO2MOpyscf(mocoeffs, mol)
 #     ao2mo.perform_rhf_full()
 #     tei_mo = ao2mo.tei_mo[0]
 

--- a/pymolresponse/tests/test_td.py
+++ b/pymolresponse/tests/test_td.py
@@ -23,7 +23,7 @@ def test_HF_both_singlet_HF_STO3G() -> None:
     occupations = occupations_from_pyscf_mol(mol, C)
     solver_tda = solvers.ExactDiagonalizationSolverTDA(C, E, occupations)
     solver_tdhf = solvers.ExactDiagonalizationSolver(C, E, occupations)
-    ao2mo = AO2MOpyscf(C, mol.verbose, mol)
+    ao2mo = AO2MOpyscf(C, mol)
     ao2mo.perform_rhf_partial()
     tei_mo = ao2mo.tei_mo
     solver_tda.tei_mo = tei_mo
@@ -111,7 +111,7 @@ HF_neutral_singlet_HF_STO3G_RPA_qchem = {
 #     occupations = occupations_from_pyscf_mol(mol, C)
 #     solver_tda = solvers.ExactDiagonalizationSolverTDA(C, E, occupations)
 #     # TODO i thought this was part of the solver interface
-#     ao2mo = AO2MOpyscf(C, mol.verbose, mol)
+#     ao2mo = AO2MOpyscf(C, mol)
 #     ao2mo.perform_uhf_partial()
 #     tei_mo = ao2mo.tei_mo
 #     solver_tda.tei_mo = tei_mo

--- a/pymolresponse/tests/test_uhf.py
+++ b/pymolresponse/tests/test_uhf.py
@@ -1,7 +1,6 @@
 """Hard-coded response equations for unrestricted wavefunctions."""
 
 import numpy as np
-
 import pyscf
 
 from pymolresponse import cphf
@@ -20,7 +19,7 @@ def test_explicit_uhf_from_rhf_outside_solver() -> None:
     mf.kernel()
     mocoeffs = mf.mo_coeff
     moenergies = mf.mo_energy
-    ao2mo = AO2MOpyscf(mocoeffs, mol.verbose, mol)
+    ao2mo = AO2MOpyscf(mocoeffs, mol)
     ao2mo.perform_rhf_full()
     assert len(ao2mo.tei_mo) == 1
     tei_mo = ao2mo.tei_mo[0]  # ty: ignore[index-out-of-bounds]
@@ -158,7 +157,7 @@ def test_explicit_uhf_outside_solver() -> None:
     assert C_a.shape == C_b.shape
     assert E_a.shape == E_b.shape
 
-    ao2mo = AO2MOpyscf(mf.mo_coeff, 5, mol)
+    ao2mo = AO2MOpyscf(mf.mo_coeff, mol)
     ao2mo.perform_uhf_full()
     assert len(ao2mo.tei_mo) == 4
     tei_mo_aaaa, tei_mo_aabb, tei_mo_bbaa, tei_mo_bbbb = ao2mo.tei_mo  # ty: ignore[invalid-assignment]
@@ -270,7 +269,7 @@ def test_explicit_uhf() -> None:
 
     solver = solvers.ExactInv(C, E, occupations)
 
-    ao2mo = AO2MOpyscf(C, mol.verbose, mol)
+    ao2mo = AO2MOpyscf(C, mol)
     ao2mo.perform_uhf_full()
     solver.tei_mo = ao2mo.tei_mo
     solver.tei_mo_type = AO2MOTransformationType.full

--- a/pymolresponse/tests/test_uncoupled.py
+++ b/pymolresponse/tests/test_uncoupled.py
@@ -1,5 +1,4 @@
 import numpy as np
-
 import pyscf
 
 from pymolresponse import cphf, operators, solvers, utils
@@ -194,7 +193,7 @@ def test_uncoupled_rhf() -> None:
 
     solver = solvers.ExactInv(C, E, occupations)
 
-    ao2mo = AO2MOpyscf(C, mol.verbose, mol)
+    ao2mo = AO2MOpyscf(C, mol)
     ao2mo.perform_rhf_partial()
     solver.tei_mo = ao2mo.tei_mo
     solver.tei_mo_type = AO2MOTransformationType.partial
@@ -252,7 +251,7 @@ def test_uncoupled_uhf() -> None:
 
     solver = solvers.ExactInv(C, E, occupations)
 
-    ao2mo = AO2MOpyscf(C, mol.verbose, mol)
+    ao2mo = AO2MOpyscf(C, mol)
     ao2mo.perform_uhf_partial()
     solver.tei_mo = ao2mo.tei_mo
     solver.tei_mo_type = AO2MOTransformationType.partial


### PR DESCRIPTION
It's not being used on the "Psi4" implementation and the pyscf side can just steal it from the molecule object.