### PR TITLE
fix: remove unused do_tda argument

### DIFF
--- a/pymolresponse/molecular_property.py
+++ b/pymolresponse/molecular_property.py
@@ -95,14 +95,7 @@ class TransitionProperty(MolecularProperty, ABC):
         mocoeffs: np.ndarray,
         moenergies: np.ndarray,
         occupations: "Occupations",
-        *,
-        do_tda: bool = False,
     ):
-        assert isinstance(do_tda, bool)
-        # FIXME this doesn't do anything as long as the driver is a required
-        # argument and TDA can be passed in instead of TDHF.
-        self.do_tda = do_tda
-
         super().__init__(program, program_obj, driver, mocoeffs, moenergies, occupations)
 
     @abstractmethod

--- a/pymolresponse/properties/ecd.py
+++ b/pymolresponse/properties/ecd.py
@@ -30,12 +30,9 @@ class ECD(TransitionProperty):
         moenergies: np.ndarray,
         occupations: "Occupations",
         *,
-        do_tda: bool = False,
         do_dipvel: bool = False,
     ) -> None:
-        super().__init__(
-            program, program_obj, driver, mocoeffs, moenergies, occupations, do_tda=do_tda
-        )
+        super().__init__(program, program_obj, driver, mocoeffs, moenergies, occupations)
         self.do_dipvel = do_dipvel
 
     def form_operators(self) -> None:

--- a/pymolresponse/tests/properties/test_optrot.py
+++ b/pymolresponse/tests/properties/test_optrot.py
@@ -230,7 +230,7 @@ def test_ORD_RPA_singlet_BC2H4_cation_HF_STO3G() -> None:
             assert (abs_diff < thresh).all()
 
     # from ecd import ECD
-    # ecd = ECD(pyscfmol, C, E, occupations, do_dipvel=True, do_tda=False)
+    # ecd = ECD(pyscfmol, C, E, occupations, do_dipvel=True)
     # ecd.run()
     # ecd.form_results()
     # ord_solver.form_operators()


### PR DESCRIPTION
This didn't do anything and was redundant with the fact that the solver, which
specifies the desired Hamiltonian, is required to be passed anyway.

This also tests that the above holds, that the TDA solver gives the same
eigenvalues as the TDHF solver with the TDA Hamiltonian.
